### PR TITLE
Fix: mac下大小写问题导致报错

### DIFF
--- a/src/reduers/index.js
+++ b/src/reduers/index.js
@@ -1,6 +1,6 @@
 import {combineReducers} from 'redux';
 import {user} from './user';
-import {chatuser} from './chatuser';
+import {chatuser} from './chatUser';
 import {chat} from './chat';
 
 const reducers = {


### PR DESCRIPTION
除了mac 上reducer合并路径大小写问题报错，还有个问题就是用户中心页刷新报错。